### PR TITLE
Added access to POS Invoice in Menu

### DIFF
--- a/posawesome/config/pos_awesome.py
+++ b/posawesome/config/pos_awesome.py
@@ -34,6 +34,11 @@ def get_data():
 				   "description": "POS Offers", 
 				   "name": "POS Offer", 
 				  },
+				{
+				   "type": "doctype", 
+				   "description": "POS Invoice", 
+				   "name": "POS Invoice", 
+				  }
             ]
 
         }

--- a/posawesome/posawesome/workspace/pos_awesome/pos_awesome.json
+++ b/posawesome/posawesome/workspace/pos_awesome/pos_awesome.json
@@ -61,6 +61,12 @@
    "label": "Referral Code",
    "link_to": "Referral Code",
    "type": "DocType"
+  },
+  {
+   "doc_view": "",
+   "label": "POS Invoice",
+   "link_to": "POS Invoice",
+   "type": "DocType"
   }
  ]
 }


### PR DESCRIPTION
Sometimes, whenever printed a receipt from POS, problems can happen such as Printer Not Ready, Paper Jam, etc. and it is needed to reprint the receipt. In this case an access to POS Invoices is needed to reprint the one needed.