### PR TITLE
added ignore permission args

### DIFF
--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -53,6 +53,7 @@ def get_opening_dialog_data():
         fields=["*"],
         limit_page_length=0,
         order_by="parent",
+        ignore_permissions=True
     )
 
     return data


### PR DESCRIPTION
added ignore permission args to pass the permission error coming on POS SCREEN. 
This error was coming "no permission to read POS Payment Method.". Therefore when ever getting data from get_list method for child tables always use **ignore_permissions=True**

**Note: Ignore Permissions always be added on Child table if data getting from get_list**