### PR TITLE
fix: update register url mpesa c2b

### DIFF
--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
@@ -34,7 +34,7 @@ class MpesaC2BRegisterURL(Document):
         confirmation_url = (
             site_url + "/api/method/posawesome.posawesome.api.m_pesa.confirmation"
         )
-        register_url = base_url + "/mpesa/c2b/v1/registerurl"
+        register_url = base_url + "/mpesa/c2b/v2/registerurl"
 
         payload = {
             "ShortCode": business_shortcode,


### PR DESCRIPTION
Register URL for mpesa c2b changed to `https://api.safaricom.co.ke/mpesa/c2b/v2/registerurl`
Made changes to reflect the same.