### PR TITLE
Update Mpesa C2B Register Url into a stand alone doctype

### DIFF
--- a/posawesome/posawesome/api/m_pesa.py
+++ b/posawesome/posawesome/api/m_pesa.py
@@ -18,7 +18,7 @@ def get_token(app_key, app_secret, base_url):
 
 
 @frappe.whitelist(allow_guest=True)
-def confirmation(**kwargs):
+def validation(**kwargs):
     try:
         args = frappe._dict(kwargs)
         doc = frappe.new_doc("Mpesa Payment Register")
@@ -47,7 +47,7 @@ def confirmation(**kwargs):
 
 
 @frappe.whitelist(allow_guest=True)
-def validation(**kwargs):
+def confirmation(**kwargs):
     args = frappe._dict(kwargs)
     frappe.log_error("validation" + "  " + str(args), "validation")
     context = {"ResultCode": 0, "ResultDesc": "Accepted"}

--- a/posawesome/posawesome/api/m_pesa.py
+++ b/posawesome/posawesome/api/m_pesa.py
@@ -62,7 +62,6 @@ def get_mpesa_mode_of_payment(company):
 		from `tabMode of Payment Account` mpa,`tabMode of Payment` mp
 		where mpa.parent = mp.name and mpa.company = %s and mp.enabled = 1 and mp.type = 'Phone'""",
         (company),
-        as_dict=0,
     )
 
     modes_of_payment = []

--- a/posawesome/posawesome/api/m_pesa.py
+++ b/posawesome/posawesome/api/m_pesa.py
@@ -62,6 +62,7 @@ def get_mpesa_mode_of_payment(company):
 		from `tabMode of Payment Account` mpa,`tabMode of Payment` mp
 		where mpa.parent = mp.name and mpa.company = %s and mp.enabled = 1 and mp.type = 'Phone'""",
         (company),
+        as_dict=1,
     )
 
     modes_of_payment = []

--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
@@ -9,10 +9,10 @@
         "consumer_key",
         "consumer_secret",
         "business_shortcode",
-        "sandbox",
         "column_break_4",
         "company",
-        "register_status"
+        "register_status",
+        "sandbox"
     ],
     "fields": [
         {
@@ -41,10 +41,13 @@
             "fieldtype": "Column Break"
         },
         {
-            "default": "0",
-            "fieldname": "sandbox",
-            "fieldtype": "Check",
-            "label": "Sandbox"
+            "fieldname": "company",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Company",
+            "options": "Company",
+            "reqd": 1
         },
         {
             "default": "Pending",
@@ -57,13 +60,10 @@
             "read_only": 1
         },
         {
-            "fieldname": "company",
-            "fieldtype": "Link",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Company",
-            "options": "Company",
-            "reqd": 1
+            "default": "0",
+            "fieldname": "sandbox",
+            "fieldtype": "Check",
+            "label": "Sandbox"
         }
     ],
     "index_web_pages_for_search": 1,

--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
@@ -18,14 +18,14 @@
         {
             "fieldname": "consumer_key",
             "fieldtype": "Data",
-            "in_list_view": 1,
+            "in_list_view": 0,
             "label": "Consumer Key",
             "reqd": 1
         },
         {
             "fieldname": "consumer_secret",
             "fieldtype": "Password",
-            "in_list_view": 1,
+            "in_list_view": 0,
             "label": "Consumer Secret",
             "reqd": 1
         },
@@ -63,12 +63,13 @@
             "default": "0",
             "fieldname": "sandbox",
             "fieldtype": "Check",
+            "in_list_view": 1,
             "label": "Sandbox"
         }
     ],
     "index_web_pages_for_search": 1,
     "links": [],
-    "modified": "2023-04-22 12:08:03.509002",
+    "modified": "2023-04-22 03:21:03.509002",
     "modified_by": "Administrator",
     "module": "POSAwesome",
     "name": "Mpesa C2B Register URL",

--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
@@ -1,128 +1,123 @@
 {
- "actions": [],
- "autoname": "field:mpesa_settings",
- "creation": "2021-11-10 03:59:38.274817",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "mpesa_settings",
-  "till_number",
-  "business_shortcode",
-  "column_break_4",
-  "company",
-  "mode_of_payment",
-  "register_status"
- ],
- "fields": [
-  {
-   "fieldname": "mpesa_settings",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Mpesa Settings",
-   "options": "Mpesa Settings",
-   "reqd": 1,
-   "unique": 1
-  },
-  {
-   "fetch_from": "mpesa_settings.till_number",
-   "fieldname": "till_number",
-   "fieldtype": "Data",
-   "label": "Till Number",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "mpesa_settings.business_shortcode",
-   "fieldname": "business_shortcode",
-   "fieldtype": "Data",
-   "label": "Business Shortcode",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "mode_of_payment",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Mode of Payment",
-   "options": "Mode of Payment",
-   "reqd": 1
-  },
-  {
-   "default": "Pending",
-   "fieldname": "register_status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Register Status",
-   "options": "Pending\nSuccess\nFailed",
-   "read_only": 1
-  },
-  {
-   "fieldname": "company",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Company",
-   "options": "Company",
-   "reqd": 1
-  }
- ],
- "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2021-11-18 05:08:03.509002",
- "modified_by": "Administrator",
- "module": "POSAwesome",
- "name": "Mpesa C2B Register URL",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts User",
-   "share": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Sales User",
-   "share": 1
-  }
- ],
- "sort_field": "modified",
- "sort_order": "DESC",
- "track_changes": 1
+    "actions": [],
+    "autoname": "field:business_shortcode",
+    "creation": "2021-11-10 03:59:38.274817",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "consumer_key",
+        "consumer_secret",
+        "business_shortcode",
+        "sandbox",
+        "column_break_4",
+        "company",
+        "register_status"
+    ],
+    "fields": [
+        {
+            "fieldname": "consumer_key",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Consumer Key",
+            "reqd": 1
+        },
+        {
+            "fieldname": "consumer_secret",
+            "fieldtype": "Password",
+            "in_list_view": 1,
+            "label": "Consumer Secret",
+            "reqd": 1
+        },
+        {
+            "fieldname": "business_shortcode",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Business Shortcode",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_4",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "fieldname": "sandbox",
+            "fieldtype": "Check",
+            "label": "Sandbox"
+        },
+        {
+            "default": "Pending",
+            "fieldname": "register_status",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Register Status",
+            "options": "Pending\nSuccess\nFailed",
+            "read_only": 1
+        },
+        {
+            "fieldname": "company",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Company",
+            "options": "Company",
+            "reqd": 1
+        }
+    ],
+    "index_web_pages_for_search": 1,
+    "links": [],
+    "modified": "2023-04-22 12:08:03.509002",
+    "modified_by": "Administrator",
+    "module": "POSAwesome",
+    "name": "Mpesa C2B Register URL",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Accounts Manager",
+            "share": 1,
+            "write": 1
+        },
+        {
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Accounts User",
+            "share": 1
+        },
+        {
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Sales User",
+            "share": 1
+        }
+    ],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "track_changes": 1
 }

--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
@@ -39,8 +39,8 @@ class MpesaC2BRegisterURL(Document):
         payload = {
             "ShortCode": business_shortcode,
             "ResponseType": "Completed",
-            "ConfirmationURL": validation_url,
-            "ValidationURL": confirmation_url,
+            "ConfirmationURL": confirmation_url,
+            "ValidationURL": validation_url,
         }
         headers = {
             "Authorization": "Bearer {0}".format(token),

--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2021, Youssef Restom and contributors
 # For license information, please see license.txt
 
-import frappe, requests
+import frappe
+import requests
 from frappe.model.document import Document
 from frappe.utils import get_request_site_address
 from posawesome.posawesome.api.m_pesa import get_token
@@ -11,28 +12,24 @@ class MpesaC2BRegisterURL(Document):
     def validate(self):
         sandbox_url = "https://sandbox.safaricom.co.ke"
         live_url = "https://api.safaricom.co.ke"
-        mpesa_settings = frappe.get_doc("Mpesa Settings", self.mpesa_settings)
-        env = "production" if not mpesa_settings.sandbox else "sandbox"
-        business_shortcode = (
-            mpesa_settings.business_shortcode
-            if env == "production"
-            else mpesa_settings.till_number
-        )
+        env = "production" if not self.sandbox else "sandbox"
+        business_shortcode = self.business_shortcode
+
         if env == "sandbox":
             base_url = sandbox_url
         else:
             base_url = live_url
         token = get_token(
-            app_key=mpesa_settings.consumer_key,
-            app_secret=mpesa_settings.get_password("consumer_secret"),
+            app_key=self.consumer_key,
+            app_secret=self.get_password("consumer_secret"),
             base_url=base_url,
         )
         site_url = get_request_site_address(True)
-        validation_url = (
-            site_url + "/api/method/posawesome.posawesome.api.m_pesa.validation"
-        )
         confirmation_url = (
             site_url + "/api/method/posawesome.posawesome.api.m_pesa.confirmation"
+        )
+        validation_url = (
+            site_url + "/api/method/posawesome.posawesome.api.m_pesa.validation"
         )
         register_url = base_url + "/mpesa/c2b/v2/registerurl"
 

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
@@ -20,6 +20,13 @@ frappe.ui.form.on("Mpesa Payment Register", {
 			"options": "Mode of Payment",
 			"default": frm.doc.mode_of_payment,
 			"reqd": 1,
+			"get_query": function() {
+				return {
+					"filters": {
+						"enabled": 1,
+					}
+				};
+			}
 		}];
 
 		if (!frm.doc.customer) {

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
@@ -18,7 +18,8 @@ frappe.ui.form.on("Mpesa Payment Register", {
 			"label": __("Mode of Payment"),
 			"fieldname": "mode_of_payment",
 			"options": "Mode of Payment",
-			"default": frm.doc.mode_of_payment
+			"default": frm.doc.mode_of_payment,
+			"reqd": 1,
 		}];
 
 		if (!frm.doc.customer) {

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
@@ -1,71 +1,8 @@
 // Copyright (c) 2021, Youssef Restom and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Mpesa Payment Register", {
-	refresh: function (frm) {
-		if (frm.doc.docstatus == 1) {
-			if (frm.doc.transamount > 0) {
-				frm.add_custom_button(__("Create Payment Entry"), function () {
-					frm.trigger("make_payment_entry");
-				});
-			}
-		}
-	},
+frappe.ui.form.on('Mpesa Payment Register', {
+	// refresh: function(frm) {
 
-	make_payment_entry: function (frm) {
-		let fields = [{
-			"fieldtype": "Link",
-			"label": __("Mode of Payment"),
-			"fieldname": "mode_of_payment",
-			"options": "Mode of Payment",
-			"default": frm.doc.mode_of_payment,
-			"reqd": 1,
-			"get_query": function() {
-				return {
-					"filters": {
-						"enabled": 1,
-					}
-				};
-			}
-		}];
-
-		if (!frm.doc.customer) {
-			fields.push({
-				"fieldtype": "Link",
-				"label": __("Customer"),
-				"fieldname": "customer",
-				"options": "Customer",
-				"default": frm.doc.customer,
-				"reqd": 1,
-			});
-		}
-
-		let dialog = new frappe.ui.Dialog({
-			title: __("Create Payment Entry"),
-			fields: fields
-		});
-
-		dialog.set_primary_action(__('Create Payment Entry'), () => {
-			var args = dialog.get_values();
-			if (!args) return;
-			dialog.hide();
-			return frappe.call({
-				type: "GET",
-				method: "posawesome.posawesome.doctype.mpesa_payment_register.mpesa_payment_register.create_payment_entry", args: {
-					"mode_of_payment": frm.doc.mode_of_payment || args.mode_of_payment,
-					"customer": frm.doc.customer || args.customer,
-					"currency": frm.doc.currency
-				},
-				freeze: true,
-				callback: function (r) {
-					if (!r.exc && r.message) {
-						frm.set_value("mode_of_payment", r.message.name);
-						frappe.model.sync(r.message);
-						frappe.set_route("Form", r.message.doctype, r.message.name);
-					}
-				}
-			});
-		});
-		dialog.show();
-	}
+	// }
 });

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.js
@@ -1,8 +1,63 @@
 // Copyright (c) 2021, Youssef Restom and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Mpesa Payment Register', {
-	// refresh: function(frm) {
+frappe.ui.form.on("Mpesa Payment Register", {
+	refresh: function (frm) {
+		if (frm.doc.docstatus == 1) {
+			if (frm.doc.transamount > 0) {
+				frm.add_custom_button(__("Create Payment Entry"), function () {
+					frm.trigger("make_payment_entry");
+				});
+			}
+		}
+	},
 
-	// }
+	make_payment_entry: function (frm) {
+		let fields = [{
+			"fieldtype": "Link",
+			"label": __("Mode of Payment"),
+			"fieldname": "mode_of_payment",
+			"options": "Mode of Payment",
+			"default": frm.doc.mode_of_payment
+		}];
+
+		if (!frm.doc.customer) {
+			fields.push({
+				"fieldtype": "Link",
+				"label": __("Customer"),
+				"fieldname": "customer",
+				"options": "Customer",
+				"default": frm.doc.customer,
+				"reqd": 1,
+			});
+		}
+
+		let dialog = new frappe.ui.Dialog({
+			title: __("Create Payment Entry"),
+			fields: fields
+		});
+
+		dialog.set_primary_action(__('Create Payment Entry'), () => {
+			var args = dialog.get_values();
+			if (!args) return;
+			dialog.hide();
+			return frappe.call({
+				type: "GET",
+				method: "posawesome.posawesome.doctype.mpesa_payment_register.mpesa_payment_register.create_payment_entry", args: {
+					"mode_of_payment": frm.doc.mode_of_payment || args.mode_of_payment,
+					"customer": frm.doc.customer || args.customer,
+					"currency": frm.doc.currency
+				},
+				freeze: true,
+				callback: function (r) {
+					if (!r.exc && r.message) {
+						frm.set_value("mode_of_payment", r.message.name);
+						frappe.model.sync(r.message);
+						frappe.set_route("Form", r.message.doctype, r.message.name);
+					}
+				}
+			});
+		});
+		dialog.show();
+	}
 });

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
@@ -41,8 +41,6 @@ class MpesaPaymentRegister(Document):
             frappe.throw(_("Customer is required"))
         if not self.mode_of_payment:
             frappe.throw(_("Mode of Payment is required"))
-        self.payment_entry = self.create_payment_entry()
-
 
 @frappe.whitelist()
 def create_payment_entry(self, mode_of_payment=None, customer=None, currency=None):

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
@@ -27,11 +27,10 @@ class MpesaPaymentRegister(Document):
                 "business_shortcode": self.businessshortcode,
                 "register_status": "Success",
             },
-            fields=["company", "mode_of_payment"],
+            fields=["company"],
         )
         if len(register_url_list) > 0:
             self.company = register_url_list[0].company
-            self.mode_of_payment = register_url_list[0].mode_of_payment
 
     def before_submit(self):
         if not self.transamount:

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
@@ -41,18 +41,18 @@ class MpesaPaymentRegister(Document):
             frappe.throw(_("Customer is required"))
         if not self.mode_of_payment:
             frappe.throw(_("Mode of Payment is required"))
+        self.payment_entry = self.create_payment_entry()
 
-@frappe.whitelist()
-def create_payment_entry(self, mode_of_payment=None, customer=None, currency=None):
-    payment_entry = create_payment_entry(
-        self.company,
-        customer,
-        self.transamount,
-        self.currency,
-        mode_of_payment,
-        self.posting_date,
-        self.transid,
-        self.posting_date,
-        self.submit_payment,
-    )
-    return payment_entry.name
+    def create_payment_entry(self):
+        payment_entry = create_payment_entry(
+            self.company,
+            self.customer,
+            self.transamount,
+            self.currency,
+            self.mode_of_payment,
+            self.posting_date,
+            self.transid,
+            self.posting_date,
+            self.submit_payment,
+        )
+        return payment_entry.name

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
@@ -43,16 +43,18 @@ class MpesaPaymentRegister(Document):
             frappe.throw(_("Mode of Payment is required"))
         self.payment_entry = self.create_payment_entry()
 
-    def create_payment_entry(self):
-        payment_entry = create_payment_entry(
-            self.company,
-            self.customer,
-            self.transamount,
-            self.currency,
-            self.mode_of_payment,
-            self.posting_date,
-            self.transid,
-            self.posting_date,
-            self.submit_payment,
-        )
-        return payment_entry.name
+
+@frappe.whitelist()
+def create_payment_entry(self, mode_of_payment=None, customer=None, currency=None):
+    payment_entry = create_payment_entry(
+        self.company,
+        customer,
+        self.transamount,
+        self.currency,
+        mode_of_payment,
+        self.posting_date,
+        self.transid,
+        self.posting_date,
+        self.submit_payment,
+    )
+    return payment_entry.name

--- a/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
@@ -126,7 +126,6 @@ export default {
         method: 'posawesome.posawesome.api.m_pesa.get_mpesa_draft_payments',
         args: {
           company: this.company,
-          mode_of_payment: this.mode_of_payment,
           mobile_no: this.mobile_no,
           full_name: this.full_name,
         },
@@ -170,7 +169,6 @@ export default {
       this.mobile_no = '';
       this.company = data.company;
       this.customer = data.customer;
-      this.mode_of_payment = data.mode_of_payment;
       this.dialog_data = '';
       this.selected = [];
     });

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -820,7 +820,7 @@ export default {
         this.redeemed_customer_credit > this.invoice_doc.grand_total
       ) {
         evntBus.$emit('show_mesage', {
-          text: `can not redeam customer credit more than invoice total`,
+          text: `can not redeem customer credit more than invoice total`,
           color: 'error',
         });
         frappe.utils.play_sound('error');
@@ -1059,7 +1059,7 @@ export default {
       const vm = this;
       if (!this.invoice_doc.contact_mobile) {
         evntBus.$emit('show_mesage', {
-          text: __(`Pleas Set Customer Mobile Number`),
+          text: __(`Please Set Customer Mobile Number`),
           color: 'error',
         });
         evntBus.$emit('open_edit_customer');


### PR DESCRIPTION
- Update Mpesa C2B Register Url into a stand alone doctype, that doesn't depend on mpesa settings, or is connected to any mode of payment, because C2B registration is only once against a M-PESA pay bill or till number of the organization.
- Get_mpesa_mode_of_payments, from modes of payment table, not from Mpesa C2B Register Url
- Update Mpesa-Payments.Vue, i.e. remove mode of payments as an argument during fetching Mpesa Payment Register