### PR TITLE
fix: remove frappe.log_error, allow c2b payments

### DIFF
--- a/posawesome/posawesome/api/m_pesa.py
+++ b/posawesome/posawesome/api/m_pesa.py
@@ -35,7 +35,6 @@ def confirmation(**kwargs):
         doc.middlename = args.get("MiddleName")
         doc.lastname = args.get("LastName")
         doc.insert(ignore_permissions=True)
-        frappe.log_error("confirmation" + "  " + str(args), "confirmation")
         frappe.db.commit()
         context = {"ResultCode": 0, "ResultDesc": "Accepted"}
         return dict(context)
@@ -48,7 +47,6 @@ def confirmation(**kwargs):
 @frappe.whitelist(allow_guest=True)
 def validation(**kwargs):
     args = frappe._dict(kwargs)
-    frappe.log_error("validation" + "  " + str(args), "validation")
     context = {"ResultCode": 0, "ResultDesc": "Accepted"}
     return dict(context)
 


### PR DESCRIPTION
removed lines prevent receiving c2b payments:
Line 38: ```frappe.log_error("confirmation" + "  " + str(args), "confirmation")```
Line 51: ```frappe.log_error("validation" + "  " + str(args), "validation")```