### PR TITLE
chore: Validations code cleaning and refactoring

### DIFF
--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -859,7 +859,7 @@ def get_draft_invoices(pos_opening_shift):
 def delete_invoice(invoice):
     if frappe.get_value("Sales Invoice", invoice, "posa_is_printed"):
         frappe.throw(_("This invoice {0} cannot be deleted").format(invoice))
-    frappe.delete_doc("Sales Invoice", invoice, force=1)
+    frappe.delete_doc("Sales Invoice", invoice, force=1, ignore_permissions=True)
     return _("Invoice {0} Deleted").format(invoice)
 
 


### PR DESCRIPTION
- Moved validations that are not related to the `item validations loop` to the outside of it.
- Now it checks if the invoice is a return first, if it is true it does its own validations and skips the `sale invoice item validations `loop.
- The `sale invoice item validation loop` now only works if the invoice is not a return.
- Removed the extra step `value` variable in the validations and now it returns the validations directly after an error message to stop looping for other conditions.
- Ignore permissions when deleting draft invoices.