### PR TITLE
Feat: Single Settings Page + Default Naming Series for payment Entry

### DIFF
--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -39,13 +39,18 @@ def create_payment_entry(
             ).format(party_account_currency=party_account_currency, currency=currency)
         )
     payment_type = "Receive"
-
+    naming_series = None
     bank = get_bank_cash_account(company, mode_of_payment)
     company_currency = frappe.get_value("Company", company, "default_currency")
     conversion_rate = get_exchange_rate(currency, company_currency, date, "for_selling")
     paid_amount, received_amount = set_paid_amount_and_received_amount(
         party_account_currency, bank, amount, payment_type, None, conversion_rate
     )
+    if(payment_type == "Receive"):
+        naming_series = frappe.db.get_single_value('POSAwesome Settings', 'receive_payment_series')
+    if(payment_type == "Pay"):
+        naming_series = frappe.db.get_single_value('POSAwesome Settings', 'pay_payment_series')
+
 
     pe = frappe.new_doc("Payment Entry")
     pe.payment_type = payment_type
@@ -73,7 +78,9 @@ def create_payment_entry(
         bank_account = get_party_bank_account(pe.party_type, pe.party)
         pe.set("bank_account", bank_account)
         pe.set_bank_account_data()
-
+    
+    if naming_series and naming_series != "":
+        pe.naming_series = naming_series
     pe.setup_party_account_field()
     pe.set_missing_values()
 

--- a/posawesome/posawesome/doctype/posawesome_settings/posawesome_settings.js
+++ b/posawesome/posawesome/doctype/posawesome_settings/posawesome_settings.js
@@ -1,0 +1,12 @@
+// Copyright (c) 2023, Youssef Restom and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('POSAwesome Settings', {
+	onload: function(frm){
+		frm.call('get_naming_series_options')
+			.then(r => {
+				frm.set_df_property("receive_payment_series", "options", r.message);
+				frm.set_df_property("pay_payment_series", "options", r.message);
+			});
+	}
+});

--- a/posawesome/posawesome/doctype/posawesome_settings/posawesome_settings.json
+++ b/posawesome/posawesome/doctype/posawesome_settings/posawesome_settings.json
@@ -1,0 +1,55 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-11-07 18:44:10.965838",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "payment_entry_settings_section",
+  "receive_payment_series",
+  "pay_payment_series"
+ ],
+ "fields": [
+  {
+   "fieldname": "receive_payment_series",
+   "fieldtype": "Select",
+   "label": "Receive Payment Entry Series"
+  },
+  {
+   "fieldname": "pay_payment_series",
+   "fieldtype": "Select",
+   "label": "Pay Payment Entry Series"
+  },
+  {
+   "fieldname": "payment_entry_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Entry Settings"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2023-11-07 20:14:01.912036",
+ "modified_by": "Administrator",
+ "module": "POSAwesome",
+ "name": "POSAwesome Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/posawesome/posawesome/doctype/posawesome_settings/posawesome_settings.py
+++ b/posawesome/posawesome/doctype/posawesome_settings/posawesome_settings.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023, Youssef Restom and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+import frappe
+from frappe import _
+
+class POSAwesomeSettings(Document):
+	@frappe.whitelist()
+	def get_naming_series_options(self):
+		options = frappe.get_meta('Payment Entry').get_field("naming_series").options
+		return options
+
+

--- a/posawesome/posawesome/doctype/posawesome_settings/test_posawesome_settings.py
+++ b/posawesome/posawesome/doctype/posawesome_settings/test_posawesome_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Youssef Restom and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPOSAwesomeSettings(FrappeTestCase):
+	pass

--- a/posawesome/posawesome/workspace/pos_awesome/pos_awesome.json
+++ b/posawesome/posawesome/workspace/pos_awesome/pos_awesome.json
@@ -1,167 +1,177 @@
 {
- "charts": [],
- "content": "[{\"id\":\"cJigdSD9mh\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">POS Awesome</span>\",\"col\":12}},{\"id\":\"4D2sc3CbN3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"POS Awesome App\",\"col\":3}},{\"id\":\"nVBkn7nfDw\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"-B_qEZqEA6\",\"type\":\"card\",\"data\":{\"card_name\":\"POS\",\"col\":4}},{\"id\":\"tsAHaUCd5l\",\"type\":\"card\",\"data\":{\"card_name\":\"Profile\",\"col\":4}},{\"id\":\"2-3HMkGou3\",\"type\":\"card\",\"data\":{\"card_name\":\"Shift\",\"col\":4}},{\"id\":\"GdPtnrazDS\",\"type\":\"card\",\"data\":{\"card_name\":\"Delivery Charges\",\"col\":4}},{\"id\":\"cABO53xhGv\",\"type\":\"card\",\"data\":{\"card_name\":\"Offers &amp; Coupons\",\"col\":4}}]",
- "creation": "2022-11-29 14:33:45.038200",
- "custom_blocks": [],
- "docstatus": 0,
- "doctype": "Workspace",
- "for_user": "",
- "hide_custom": 0,
- "icon": "retail",
- "idx": 0,
- "is_hidden": 0,
- "label": "POS Awesome",
- "links": [
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "POS Awesome",
-   "link_count": 0,
-   "link_to": "posapp",
-   "link_type": "Page",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Profile",
-   "link_count": 1,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "POS Profile",
-   "link_count": 0,
-   "link_to": "POS Profile",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Delivery Charges",
-   "link_count": 1,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Delivery Charges",
-   "link_count": 0,
-   "link_to": "Delivery Charges",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Offers &amp; Coupons",
-   "link_count": 3,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Offers",
-   "link_count": 0,
-   "link_to": "POS Offer",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Coupons",
-   "link_count": 0,
-   "link_to": "POS Coupon",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Referral Code",
-   "link_count": 0,
-   "link_to": "Referral Code",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "POS",
-   "link_count": 1,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "POS Awesome App",
-   "link_count": 0,
-   "link_to": "posapp",
-   "link_type": "Page",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Shift",
-   "link_count": 2,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Opening Shift",
-   "link_count": 0,
-   "link_to": "POS Opening Shift",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Closing Shift",
-   "link_count": 0,
-   "link_to": "POS Closing Shift",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  }
- ],
- "modified": "2023-06-07 17:35:14.887611",
- "modified_by": "Administrator",
- "module": "POSAwesome",
- "name": "POS Awesome",
- "number_cards": [],
- "owner": "Administrator",
- "parent_page": "",
- "public": 1,
- "quick_lists": [],
- "roles": [],
- "sequence_id": 1.0,
- "shortcuts": [
-  {
-   "color": "Grey",
-   "doc_view": "List",
-   "label": "POS Awesome App",
-   "link_to": "posapp",
-   "type": "Page"
-  }
- ],
- "title": "POS Awesome"
-}
+    "charts": [],
+    "content": "[{\"id\":\"cJigdSD9mh\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">POS Awesome</span>\",\"col\":12}},{\"id\":\"4D2sc3CbN3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"POS Awesome App\",\"col\":3}},{\"id\":\"nVBkn7nfDw\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"-B_qEZqEA6\",\"type\":\"card\",\"data\":{\"card_name\":\"POS\",\"col\":4}},{\"id\":\"tsAHaUCd5l\",\"type\":\"card\",\"data\":{\"card_name\":\"Profile\",\"col\":4}},{\"id\":\"2-3HMkGou3\",\"type\":\"card\",\"data\":{\"card_name\":\"Shift\",\"col\":4}},{\"id\":\"GdPtnrazDS\",\"type\":\"card\",\"data\":{\"card_name\":\"Delivery Charges\",\"col\":4}},{\"id\":\"cABO53xhGv\",\"type\":\"card\",\"data\":{\"card_name\":\"Offers &amp; Coupons\",\"col\":4}}]",
+    "creation": "2022-11-29 14:33:45.038200",
+    "custom_blocks": [],
+    "docstatus": 0,
+    "doctype": "Workspace",
+    "for_user": "",
+    "hide_custom": 0,
+    "icon": "retail",
+    "idx": 0,
+    "is_hidden": 0,
+    "label": "POS Awesome",
+    "links": [
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "POS Awesome",
+      "link_count": 0,
+      "link_to": "posapp",
+      "link_type": "Page",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Profile",
+      "link_count": 1,
+      "onboard": 0,
+      "type": "Card Break"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "POS Profile",
+      "link_count": 0,
+      "link_to": "POS Profile",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Delivery Charges",
+      "link_count": 1,
+      "onboard": 0,
+      "type": "Card Break"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Delivery Charges",
+      "link_count": 0,
+      "link_to": "Delivery Charges",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Offers &amp; Coupons",
+      "link_count": 3,
+      "onboard": 0,
+      "type": "Card Break"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Offers",
+      "link_count": 0,
+      "link_to": "POS Offer",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Coupons",
+      "link_count": 0,
+      "link_to": "POS Coupon",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Referral Code",
+      "link_count": 0,
+      "link_to": "Referral Code",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Shift",
+      "link_count": 2,
+      "onboard": 0,
+      "type": "Card Break"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Opening Shift",
+      "link_count": 0,
+      "link_to": "POS Opening Shift",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "Closing Shift",
+      "link_count": 0,
+      "link_to": "POS Closing Shift",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "POS",
+      "link_count": 2,
+      "onboard": 0,
+      "type": "Card Break"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "POS Awesome App",
+      "link_count": 0,
+      "link_to": "posapp",
+      "link_type": "Page",
+      "onboard": 0,
+      "type": "Link"
+     },
+     {
+      "hidden": 0,
+      "is_query_report": 0,
+      "label": "POSAwesome Settings",
+      "link_count": 0,
+      "link_to": "POSAwesome Settings",
+      "link_type": "DocType",
+      "onboard": 0,
+      "type": "Link"
+     }
+    ],
+    "modified": "2023-11-08 15:53:51.150081",
+    "modified_by": "Administrator",
+    "module": "POSAwesome",
+    "name": "POS Awesome",
+    "number_cards": [],
+    "owner": "Administrator",
+    "parent_page": "",
+    "public": 1,
+    "quick_lists": [],
+    "roles": [],
+    "sequence_id": 1.0,
+    "shortcuts": [
+     {
+      "color": "Grey",
+      "doc_view": "List",
+      "label": "POS Awesome App",
+      "link_to": "posapp",
+      "type": "Page"
+     }
+    ],
+    "title": "POS Awesome"
+   }


### PR DESCRIPTION
- Added a new doctype called POSAwesome Settings for Global Settings across POS Profiles.
- Added the ability to set a default naming series for payment entries from the POSAwesome (can be set at the new doc - POSAwesome Settings)
- If the default naming series is set in the POSAwesome Settings (the new doc) then it will use that instead of the default value of the original field in the payment entry doctype.

<img width="991" alt="image" src="https://github.com/yrestom/POS-Awesome/assets/40042269/c695db30-128b-4bf8-84fe-b24f8bb1ce4b">
